### PR TITLE
closes #72 to query database to see if a fire slug exists

### DIFF
--- a/calfire_tracker/management/commands/scraper_wildfires.py
+++ b/calfire_tracker/management/commands/scraper_wildfires.py
@@ -142,8 +142,16 @@ def save_data_from_dict_to_model(data_dict):
     else:
         more_info = None
 
-    fire_slug = '%s' % (slugifyFireName(fire_name))
     county_slug = '%s' % (slugifyFireName(county))
+    scraped_fire_slug = '%s' % (slugifyFireName(fire_name))
+
+    # if an object with fire slug exists in the database
+    if not CalWildfire.objects.filter(fire_slug=scraped_fire_slug).exists():
+        fire_slug = scraped_fire_slug
+
+    # if it does, append the county slug to the fire slug
+    else:
+        fire_slug = '%s-%s' % (scraped_fire_slug, county_slug)
 
     if data_dict.has_key('location'):
         location = titlecase(data_dict['location'])
@@ -300,8 +308,6 @@ def save_data_from_dict_to_model(data_dict):
         obj.last_updated = last_updated
         obj.administrative_unit = administrative_unit
         obj.more_info = more_info
-        obj.fire_slug = fire_slug
-        obj.county_slug = county_slug
         obj.location = location
         obj.injuries = injuries
         obj.evacuations = evacuations

--- a/calfire_tracker/models.py
+++ b/calfire_tracker/models.py
@@ -90,7 +90,7 @@ class CalWildfire(models.Model):
         	self.created_fire_id = self.created_fire_id
         if (self.location_latitude is None) or (self.location_longitude is None):
             self.fill_geocode_data()
-        super(CalWildfire, self).save()
+        super(CalWildfire, self).save(*args, **kwargs)
 
 class WildfireUpdate(models.Model):
     date_time_update = models.DateTimeField('Time of Update', null=True, blank=True)


### PR DESCRIPTION
Since we're using the fire slug to return the single fire page we should be able to query if a fire slug already exists and then append the county to the fire slug to avoid 404 errors when a fire with the same name appears in the data base...
