### PR TITLE
Update social URLs to new domain

### DIFF
--- a/calfire_tracker/templates/403.html
+++ b/calfire_tracker/templates/403.html
@@ -10,9 +10,9 @@
 {% block keywords %}KPCC, Southern California Public Radio, 89.3, 89.3 KPCC, Southern California, Pasadena, Los Angeles, Fires, Wildfires, Fire Tracker, News{% endblock %}
 {% block og_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{% endblock %}
 {% block og_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{% endblock %}
 {% block twitter_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
 <!-- end meta -->

--- a/calfire_tracker/templates/404.html
+++ b/calfire_tracker/templates/404.html
@@ -10,9 +10,9 @@
 {% block keywords %}KPCC, Southern California Public Radio, 89.3, 89.3 KPCC, Southern California, Pasadena, Los Angeles, Fires, Wildfires, Fire Tracker, News{% endblock %}
 {% block og_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{% endblock %}
 {% block og_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{% endblock %}
 {% block twitter_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
 <!-- end meta -->

--- a/calfire_tracker/templates/500.html
+++ b/calfire_tracker/templates/500.html
@@ -8,9 +8,9 @@
 {% block keywords %}KPCC, Southern California Public Radio, 89.3, 89.3 KPCC, Southern California, Pasadena, Los Angeles, Fires, Wildfires, Fire Tracker, News{% endblock %}
 {% block og_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{% endblock %}
 {% block og_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{% endblock %}
 {% block twitter_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
 <!-- end meta -->

--- a/calfire_tracker/templates/archives.html
+++ b/calfire_tracker/templates/archives.html
@@ -11,9 +11,9 @@
 {% block og_title %}Archives | Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}website{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker/wildfires/archives/{% endblock %}
+{% block og_url %}http://firetracker.scpr.org/wildfires/archives/{% endblock %}
 {% block og_description %}89.3 KPCC's Fire Tracker archives contains historic wildfire data from CalFire and other sources.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker/wildfires/archives/{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org/wildfires/archives/{% endblock %}
 {% block twitter_title %}Archives | Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}89.3 KPCC's Fire Tracker archives contains historic wildfire data from CalFire and other sources.{% endblock %}
 <!-- end meta -->

--- a/calfire_tracker/templates/base.html
+++ b/calfire_tracker/templates/base.html
@@ -30,7 +30,7 @@
         <meta property="og:description" content="{% block og_description %}{% endblock %}" />
         <meta name="twitter:card" content="summary"/>
         <meta name="twitter:url" content="{% block twitter_url %}{% endblock %}"/>
-        <meta name="twitter:domain" content="http://projects.scpr.org/firetracker"/>
+        <meta name="twitter:domain" content="http://firetracker.scpr.org"/>
         <meta name="twitter:site" content="KPCC"/>
         <meta name="twitter:title" content="{% block twitter_title %}{% endblock %}"/>
         <meta name="twitter:description" content="{% block twitter_description %}{% endblock %}"/>

--- a/calfire_tracker/templates/detail.html
+++ b/calfire_tracker/templates/detail.html
@@ -13,9 +13,9 @@
 {% block og_title %}{{ calwildfire.fire_name }} | KPCC's Fire Tracker{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}article{% endblock %}
-{% block og_url %}http://projects.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
 {% block og_description %}Get details about the {{ calwildfire.fire_name }} in {{ calwildfire.county }} that began burning {{ calwildfire.date_time_started|date:"l, F j, Y" }} at {{ calwildfire.date_time_started|date:"g:i a" }} near {{ calwildfire.location }}.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
 {% block twitter_title %}{{ calwildfire.fire_name }} | KPCC's Fire Tracker{% endblock %}
 {% block twitter_description %}Get details about the {{ calwildfire.fire_name }} in {{ calwildfire.county }} that began burning {{ calwildfire.date_time_started|date:"l, F j, Y" }} at {{ calwildfire.date_time_started|date:"g:i a" }} near {{ calwildfire.location }}.{% endblock %}
 <!-- end meta -->
@@ -79,10 +79,10 @@
             </aside>
             <aside class="share">
                 <ul class="clearfix">
-                    <li class="em"><a title="Email a link" href="mailto:?subject=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker&body={{ calwildfire.fire_name }}:%20http%3A%2F%2Fprojects.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Email a link</a></li>
-                    <li class="tu"><a title="Share on Tumblr" href="http://tumblr.com/share?s=&amp;v=3&amp;t=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker&amp;u=http%3A%2F%2Fprojects.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Share on Tumblr</a></li>
-                    <li class="tw"><a title="Share on Twitter" href="https://twitter.com/intent/tweet?text=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker:%20http%3A%2F%2Fprojects.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Share on Twitter</a></li>
-                    <li class="fa"><a title="Share on Facebook" href="https://www.facebook.com/sharer.php?u=http%3A%2F%2Fprojects.scpr.org{{ calwildfire.get_absolute_url|urlencode }}&amp;t=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}">Share on Facebook</a></li>
+                    <li class="em"><a title="Email a link" href="mailto:?subject=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker&body={{ calwildfire.fire_name }}:%20http%3A%2F%2Ffiretracker.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Email a link</a></li>
+                    <li class="tu"><a title="Share on Tumblr" href="http://tumblr.com/share?s=&amp;v=3&amp;t=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker&amp;u=http%3A%2F%2Ffiretracker.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Share on Tumblr</a></li>
+                    <li class="tw"><a title="Share on Twitter" href="https://twitter.com/intent/tweet?text=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}%20via%20@KPCC's%20FireTracker:%20http%3A%2F%2Ffiretracker.scpr.org{{ calwildfire.get_absolute_url|urlencode }}">Share on Twitter</a></li>
+                    <li class="fa"><a title="Share on Facebook" href="https://www.facebook.com/sharer.php?u=http%3A%2F%2Ffiretracker.scpr.org{{ calwildfire.get_absolute_url|urlencode }}&amp;t=Learn%20about%20the%20{{ calwildfire.fire_name|urlencode }}%20in%20{{ calwildfire.county|urlencode }}">Share on Facebook</a></li>
                     <li class="card"><button class="share-this-fire">Share this fire</button></li>
                 </ul>
             </aside>

--- a/calfire_tracker/templates/embeddable.html
+++ b/calfire_tracker/templates/embeddable.html
@@ -14,9 +14,9 @@
 {% block og_title %}{{ calwildfire.fire_name }} embeddable card | KPCC's Fire Tracker{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}article{% endblock %}
-{% block og_url %}http://projects.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
 {% block og_description %}Get details about the {{ calwildfire.fire_name }} in {{ calwildfire.county }} that began burning {{ calwildfire.date_time_started|date:"l, F j, Y" }} at {{ calwildfire.date_time_started|date:"g:i a" }} near {{ calwildfire.location }}.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{{ calwildfire.get_absolute_url }}{% endblock %}
 {% block twitter_title %}{{ calwildfire.fire_name }} embeddable card | KPCC's Fire Tracker{% endblock %}
 {% block twitter_description %}Get details about the {{ calwildfire.fire_name }} in {{ calwildfire.county }} that began burning {{ calwildfire.date_time_started|date:"l, F j, Y" }} at {{ calwildfire.date_time_started|date:"g:i a" }} near {{ calwildfire.location }}.{% endblock %}
 <!-- end meta -->

--- a/calfire_tracker/templates/index.html
+++ b/calfire_tracker/templates/index.html
@@ -12,9 +12,9 @@
 {% block og_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}website{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{% endblock %}
 {% block og_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{% endblock %}
 {% block twitter_title %}Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}89.3 KPCC's Fire Tracker is a tool for following and researching California wildfires.{% endblock %}
 <!-- end meta -->
@@ -67,10 +67,10 @@
                 <h3>KPCC's tool for following &amp; researching California wildfires.</h3>
                 <aside class="share">
                     <ul class="clearfix">
-                        <li class="em"><a title="Email a link" href="mailto:?subject=KPCC's Fire Tracker is a tool for following and researching California wildfires&body=View KPCC's Fire Tracker here: http%3A%2F%2Fprojects.scpr.org%2Ffiretracker%2F">Email a link</a></li>
-                        <li class="tu"><a title="Share on Tumblr" href="http://tumblr.com/share?s=&amp;v=3&amp;t=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires&amp;u=http%3A%2F%2Fprojects.scpr.org%2Ffiretracker%2F">Share on Tumblr</a></li>
-                        <li class="tw"><a title="Share on Twitter" href="https://twitter.com/intent/tweet?text=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires%20:%20http%3A%2F%2Fprojects.scpr.org%2Ffiretracker%2F">Share on Twitter</a></li>
-                        <li class="fa"><a title="Share on Facebook" href="https://www.facebook.com/sharer.php?u=http%3A%2F%2Fprojects.scpr.org%2Ffiretracker%2F&amp;t=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires">Share on Facebook</a></li>
+                        <li class="em"><a title="Email a link" href="mailto:?subject=KPCC's Fire Tracker is a tool for following and researching California wildfires&body=View KPCC's Fire Tracker here: http%3A%2F%2Ffiretracker.scpr.org%2F">Email a link</a></li>
+                        <li class="tu"><a title="Share on Tumblr" href="http://tumblr.com/share?s=&amp;v=3&amp;t=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires&amp;u=http%3A%2F%2Ffiretracker.scpr.org%2F">Share on Tumblr</a></li>
+                        <li class="tw"><a title="Share on Twitter" href="https://twitter.com/intent/tweet?text=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires%20:%20http%3A%2F%2Ffiretracker.scpr.org%2F">Share on Twitter</a></li>
+                        <li class="fa"><a title="Share on Facebook" href="https://www.facebook.com/sharer.php?u=http%3A%2F%2Ffiretracker.scpr.org%2F&amp;t=KPCC%27s%20Fire%20Tracker%20is%20a%20tool%20for%20following%20and%20researching%20California%20wildfires">Share on Facebook</a></li>
                     </ul>
                 </aside>
             </div>

--- a/calfire_tracker/templates/largest_ca_fires.html
+++ b/calfire_tracker/templates/largest_ca_fires.html
@@ -11,9 +11,9 @@
 {% block og_title %}Largest California Wildfires | Fire Tracker | 89.3 KPCC{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}website{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker/wildfires/archives/{% endblock %}
+{% block og_url %}http://firetracker.scpr.org/wildfires/archives/{% endblock %}
 {% block og_description %}Based on historical data, these wildfires consumed the most acreage in California history.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker/wildfires/archives/{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org/wildfires/archives/{% endblock %}
 {% block twitter_title %}Largest California Wildfires | Fire Tracker | 89.3 KPCC{% endblock %}
 {% block twitter_description %}Based on historical data, these wildfires consumed the most acreage in California history.{% endblock %}
 <!-- end meta -->

--- a/templates/flatpages/default.html
+++ b/templates/flatpages/default.html
@@ -12,9 +12,9 @@
 {% block og_title %}{{ flatpage.title }}{% endblock %}
 {% block og_site_name %}89.3 KPCC{% endblock %}
 {% block og_type %}website{% endblock %}
-{% block og_url %}http://projects.scpr.org/firetracker{{ flatpage.url }}{% endblock %}
+{% block og_url %}http://firetracker.scpr.org{{ flatpage.url }}{% endblock %}
 {% block og_description %}Fire Tracker, KPCC's tool for following & researching California wildfires, contains fire information displayed by the California Department of Forestry and Fire Protection.{% endblock %}
-{% block twitter_url %}http://projects.scpr.org/firetracker{{ flatpage.url }}{% endblock %}
+{% block twitter_url %}http://firetracker.scpr.org{{ flatpage.url }}{% endblock %}
 {% block twitter_title %}{{ flatpage.title }}{% endblock %}
 {% block twitter_description %}Fire Tracker, KPCC's tool for following & researching California wildfires, contains fire information displayed by the California Department of Forestry and Fire Protection.{% endblock %}
 <!-- end meta -->


### PR DESCRIPTION
These URLs are for social networks and would likely mess up share counts if they were changed. These don't have to be changed — everything will work the same. The only advantage to updating these URLs is consistency. I'll leave it up to you.
