### PR TITLE
Fix typo that was causing scraping to fail for some incidents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ tmp/*
 public/static/*
 
 project_notes
+.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:2.7.13-alpine
+
+MAINTAINER Ben Titcomb <btitcomb@scpr.org>
+
+RUN apk update && apk add \
+  autoconf \
+  bash \
+  g++ \
+  gcc \
+  git \
+  libc-dev \
+  libffi-dev \
+  libgcc \
+  libxml2-dev \
+  libxslt-dev \
+  make \
+  mariadb-dev \
+  py-mysqldb \
+  yaml \
+  yaml-dev \
+  zlib-dev
+
+USER root
+ENV HOME /root
+WORKDIR $HOME
+COPY . .
+
+ENV PATH="/root/bin:${PATH}"
+
+RUN pip install -r requirements.txt
+RUN echo "titlecase==0.5.1" >> requirements.txt
+RUN pip install -r requirements.txt
+
+# RUN python ./manage.py syncdb
+# RUN python ./manage.py migrate
+
+EXPOSE 8000
+
+ENTRYPOINT /bin/bash
+
+# CMD python ./manage.py runserver
+
+# docker run --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v /dev/firetracker:/root firetracker 
+# docker run -it --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v /dev/firetracker:/root firetracker 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,7 @@ RUN pip install -r requirements.txt
 RUN echo "titlecase==0.5.1" >> requirements.txt
 RUN pip install -r requirements.txt
 
-# RUN python ./manage.py syncdb
-# RUN python ./manage.py migrate
-
 EXPOSE 8000
 
 ENTRYPOINT /bin/bash
 
-# CMD python ./manage.py runserver
-
-# docker run --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v /dev/firetracker:/root firetracker 
-# docker run -it --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v /dev/firetracker:/root firetracker 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Fire Tracker, KPCC's tool for following & researching California wildfires, cont
 
         pip install -r requirements.txt
 
+### Docker Setup
+
+These instructions assume you've created a Docker Network that includes a MySQL|MariaDB instance.
+
+* Build the image from the Dockerfile
+
+        docker build -t firetracker .
+
+* Create a container with the local project folder as a volume and connected to your network
+
+        docker create -it --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v ~/workspace/firetracker:/root --name firetracker-dev firetracker
+
 ### License
 
 **GNU General Public License V2**

--- a/calfire_tracker/manager_calfire.py
+++ b/calfire_tracker/manager_calfire.py
@@ -405,7 +405,7 @@ class Normalizer(object):
         else:
             f["total_helicopters"] = None
         if f.has_key("total_fire_engines"):
-            f["total_fire_engines"] = self.extract_initial_integer(fire["total_fire_engines"])
+            f["total_fire_engines"] = self.extract_initial_integer(f["total_fire_engines"])
         else:
             f["total_fire_engines"] = None
         if f.has_key("total_fire_personnel"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ South==0.7.6
 tweepy==2.1
 twitter==1.17.1
 yolk==0.4.3
+ez_setup==0.9


### PR DESCRIPTION
In manager_calfire.py line 408:

`f["total_fire_engines"] = self.extract_initial_integer(fire["total_fire_engines"])`

should be:

`f["total_fire_engines"] = self.extract_initial_integer(f["total_fire_engines"])`

Since this line is in an if statement, any incident that contains total_fire_engines information would fail because of the incorrect variable name, and subsequent incidents would not get scraped.

This PR fixes that, and also adds the Dockerfile I've been using just for the sake of it.