### PR TITLE
Solve some crashing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ Fire Tracker, KPCC's tool for following & researching California wildfires, cont
 
 These instructions assume you've created a Docker Network that includes a MySQL|MariaDB instance.
 
-* Build the image from the Dockerfile
+* Get a Deploybot token and assign it to an environment variable.  Skip this if you set up your own database.
 
-        docker build -t firetracker .
+        export DEPLOYBOT_TOKEN=xxxxxxxxxx
 
-* Create a container with the local project folder as a volume and connected to your network
+* Compose the Docker containers.
 
-        docker create -it --network="assethost-network" --network-alias=["firetracker"] -p 80:8000 -v ~/workspace/firetracker:/root --name firetracker-dev firetracker
+        docker-compose up -d
+
+### Running the Scraper
+
+`python manage.py scraper_wildfires`
 
 ### License
 

--- a/calfire_tracker/data_manager.py
+++ b/calfire_tracker/data_manager.py
@@ -614,7 +614,9 @@ class WildfireDataClient(object):
 
         fire["county_slug"] = self.UTIL.slugifyFireName(fire["county"])
 
-        fire["fire_slug"] = self.UTIL.slugifyFireName(fire["name"])
+        # fire["fire_slug"] = self.UTIL.slugifyFireName(fire["name"])
+        ## 👆 disabling this because models.py#158-159 appears to generate
+        ## a better slug if no slug has been generated yet.
 
         fire["naming_slug"] = "%s-%s" % (fire["fire_slug"], fire["county_slug"])
 

--- a/calfire_tracker/manager_calfire.py
+++ b/calfire_tracker/manager_calfire.py
@@ -42,11 +42,14 @@ class Prepper(object):
         else:
             url = link[1]["href"].strip()
         if url:
-            is_inciweb = re.search("inciweb", url)
+            is_inciweb   = re.search("inciweb", url)
             is_riverside = re.search("rvcfire", url)
+            is_twitter   = re.search("twitter", url)
             if is_inciweb:
                 output = None
             elif is_riverside:
+                output = None
+            elif is_twitter:
                 output = None
             else:
                 output = "http://www.fire.ca.gov%s" % (url)

--- a/calfire_tracker/views.py
+++ b/calfire_tracker/views.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date, time, timedelta
-from django.shortcuts import get_object_or_404, render_to_response, render
+from django.shortcuts import get_object_or_404, get_list_or_404, render_to_response, render
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest, Http404
 from django.views.decorators.clickjacking import xframe_options_exempt, xframe_options_sameorigin
 from django.core.urlresolvers import reverse
@@ -47,7 +47,7 @@ def index(request):
 
 @xframe_options_sameorigin
 def detail(request, fire_slug):
-    calwildfire = get_object_or_404(CalWildfire, fire_slug=fire_slug)
+    calwildfire = get_list_or_404(CalWildfire, fire_slug=fire_slug)[-1]
     calwildfires = CalWildfire.objects.exclude(containment_percent=None).order_by('-date_time_started', 'fire_name', 'containment_percent')[0:15]
     wildfire_updates = WildfireUpdate.objects.filter(fire_name__fire_name=calwildfire.fire_name).order_by('-date_time_update')
     result_list = WildfireTweet.objects.filter(tweet_hashtag=calwildfire.twitter_hashtag).order_by('-tweet_created_at')[0:15]
@@ -64,7 +64,7 @@ def detail(request, fire_slug):
 
 @xframe_options_sameorigin
 def revamp_detail(request, fire_slug):
-    calwildfire = get_object_or_404(CalWildfire, fire_slug=fire_slug)
+    calwildfire = get_list_or_404(CalWildfire, fire_slug=fire_slug)[-1]
     calwildfires = CalWildfire.objects.exclude(containment_percent=None).order_by('-date_time_started', 'fire_name', 'containment_percent')[0:15]
     wildfire_updates = WildfireUpdate.objects.filter(fire_name__fire_name=calwildfire.fire_name).order_by('-date_time_update')
     result_list = WildfireTweet.objects.filter(tweet_hashtag=calwildfire.twitter_hashtag).order_by('-tweet_created_at')[0:15]
@@ -81,7 +81,7 @@ def revamp_detail(request, fire_slug):
 
 @xframe_options_exempt
 def embeddable(request, fire_slug):
-    calwildfire = get_object_or_404(CalWildfire, fire_slug=fire_slug)
+    calwildfire = get_list_or_404(CalWildfire, fire_slug=fire_slug)[-1]
     cache_expire = (60*15)
     cache_timestamp = calwildfire.last_saved
     return render_to_response('embeddable.html', {
@@ -127,7 +127,7 @@ def oembed(request):
     match       = regex.search(url)
     fire_slug   = match.groups()[0]
 
-    calwildfire = get_object_or_404(CalWildfire, fire_slug=fire_slug)
+    calwildfire = get_list_or_404(CalWildfire, fire_slug=fire_slug)[-1]
 
     embed_html = ("<iframe width=\"100%%\" height=\"%s\" scrolling=\"no\" "
                   "frameborder=\"no\" src=\"%s%sembed\"></iframe>") % (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+
+  firetracker: &default
+    # image: scprdev/firetracker
+    build: .
+    ports:
+      - 8000:8000/tcp
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./:/root
+    networks:
+      firetracker-network:
+        aliases:
+         - firetracker
+
+  firetracker-database:
+    image: scpr/restore-percona-backup
+    ports:
+      - 3306:3306/tcp
+    environment:
+      - "DEPLOYBOT_TOKEN=${DEPLOYBOT_TOKEN}"
+    entrypoint: /restore-backup.sh $DEPLOYBOT_TOKEN
+    networks:
+      firetracker-network:
+        aliases:
+         - firetracker-database
+
+networks:
+  firetracker-network:


### PR DESCRIPTION
Related to #214.

There was existing code to write a more specific fire slug if a current fire slug didn't already exist.  I simply disabled the line that writes the old slug so that the more specific slug format is always used.

Secondly, I changed the views to not return an error if multiple incidents with the same slug exist.  Instead, it defaults to the most recent fire because that's what people are usually going to want to see.

Also, the scraper was failing on details links with an href to twitter.  I just added a rule similar to the rvc and inciweb links to return None so that the scraper doesn't try to parse details from that URL.  I'm sure there's a better way to handle this scenario but I thought I'd follow the existing pattern for now to get this problem to go away.

Lastly, I added a docker-compose file for convenience.  To get Firetracker up and running for development purposes, it should be as simple as setting an environment variable and running `docker compose up`.